### PR TITLE
Fix rel="me" link

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,7 +30,7 @@
         <ul>
           {{- $currentPage := . -}} {{ range .Site.Menus.social -}}
           <li class="">
-            <a href="{{ .URL | absLangURL }}" target="blank" class="">
+            <a href="{{ .URL | absLangURL }}" target="blank" rel="me" class="">
               {{ .Name }}
             </a>
           </li>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,3 @@
-<a rel="me" href="https://chaos.social/@xHain_hackspace">Mastodon</a>
 <header>
     <div id="header-wrapper">
         <div class="logo"><a href="{{ .Site.BaseURL }}">xHain | hack+makespace</a></div>


### PR DESCRIPTION
Instead of having a floating link (that was unexpected to me, see screenshot below).

<img width="255" alt="Screenshot 2023-07-02 at 16 14 58" src="https://github.com/xHain-hackspace/xhain-website/assets/1328733/bcf2bd39-362b-4a74-b8c2-e10c2197d99f">


I added "rel=me" to all the social links, which should provide the same benefit in the end, being validated on Mastodon