### PR TITLE
Fix missing `</div>` for "main-wrapper" for default layout

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -9,6 +9,7 @@
   <main>
     <div id="main-wrapper">
       {{ .Content }}
+    </div>
   </main>
   {{ partial "footer" . }}
 </div>


### PR DESCRIPTION
Found via https://validator.w3.org/nu/?doc=https%3A%2F%2Fx-hain.de%2Fde%2F

<img width="356" alt="Screenshot 2023-07-02 at 16 24 26" src="https://github.com/xHain-hackspace/xhain-website/assets/1328733/3a3cf13e-7079-4480-9187-89e421b867c4">
