### PR TITLE
Remove target="blank" from links

### DIFF
--- a/content/de/_index.md
+++ b/content/de/_index.md
@@ -31,11 +31,11 @@ Ob Hacker:in, Maker:in oder einfach nur neugierig, ihr seid im xHain willkommen!
 
 **Wir möchten das sich im xHain alle wohl fühlen!**
 
-<a href="https://wiki.x-hain.de/de/xHain/xRoots" target="_blank"><img alt="xRoots symbol" src="/images/logo/xroots.png" style="float: left; padding: 10px 20px 0 0; width: 100px; height: auto;" /></a>
+<a href="https://wiki.x-hain.de/de/xHain/xRoots"><img alt="xRoots symbol" src="/images/logo/xroots.png" style="float: left; padding: 10px 20px 0 0; width: 100px; height: auto;" /></a>
 
-Unsere <a href="https://wiki.x-hain.de/de/xHain/xRoots" target="_blank">xRoots Mentor:innen</a> sind für euch da: Wir erleichtern euch den Einstieg, zeigen euch den xHain und beantworten eure Fragen. Wenn ihr besondere Bedürfnisse oder Anliegen habt, dann kümmern wir uns darum. Halte einfach Montags nach Menschen mit dem xRoots Logo/Badge Ausschau oder sprich uns im <a href="https://chat.x-hain.de" target="_blank">Chat</a> an.
+Unsere <a href="https://wiki.x-hain.de/de/xHain/xRoots">xRoots Mentor:innen</a> sind für euch da: Wir erleichtern euch den Einstieg, zeigen euch den xHain und beantworten eure Fragen. Wenn ihr besondere Bedürfnisse oder Anliegen habt, dann kümmern wir uns darum. Halte einfach Montags nach Menschen mit dem xRoots Logo/Badge Ausschau oder sprich uns im <a href="https://chat.x-hain.de">Chat</a> an.
 
-Der xHain ist ein rauchfreier Ort. Wer rauchen will, kann das draußen tun. Wer ein Arschloch ist, z.B. sexistisch, rassistisch, oder homophob, braucht nicht zu kommen. Lest bitte und beachtet unsere <a href="https://wiki.x-hain.de/de/xHain/spacerules" target="_blank">Space-Regeln</a>. 
+Der xHain ist ein rauchfreier Ort. Wer rauchen will, kann das draußen tun. Wer ein Arschloch ist, z.B. sexistisch, rassistisch, oder homophob, braucht nicht zu kommen. Lest bitte und beachtet unsere <a href="https://wiki.x-hain.de/de/xHain/spacerules">Space-Regeln</a>. 
 
 ## Der Space
 

--- a/content/de/participate.md
+++ b/content/de/participate.md
@@ -4,12 +4,12 @@ date: 2021-06-15
 draft: false
 ---
 
-Eigentlich darf man gerne immer vorbeischauen, allerdings haben wir bis auf Montag Abend keine regulären Öffnungszeiten. Viele aktive Member haben selbst einen Schlüssel. Sofern offen ist, oder Veranstaltungen angekündigt sind, ist jederzeit jede Person willkommen. Fragt auch gerne im <a href="https://chat.x-hain.de" target="_blank">Chat</a>, wann jemand im xHain ist.
+Eigentlich darf man gerne immer vorbeischauen, allerdings haben wir bis auf Montag Abend keine regulären Öffnungszeiten. Viele aktive Member haben selbst einen Schlüssel. Sofern offen ist, oder Veranstaltungen angekündigt sind, ist jederzeit jede Person willkommen. Fragt auch gerne im <a href="https://chat.x-hain.de">Chat</a>, wann jemand im xHain ist.
 Der xHain versteht sich als Do-ocracy und lebt vom Engagement und den Ideen der Member. Das heißt, dass Member selbständig ihre Projekte aussuchen und ausführen. 
 
 ## Member werden
 
-Member sind das Herz unseres Spaces. Üblicherweise spenden Member 13,37 € oder mehr im Monat und sind am aktivsten in der Benutzung der Geräte und Werkzeuge, sowie der Gestaltung des xHains. Im Wiki erfährt ihr <a href="https://wiki.x-hain.de/de/xHain/members" target="_blank">mehr Details über die Mitgliedschaft</a>.
+Member sind das Herz unseres Spaces. Üblicherweise spenden Member 13,37 € oder mehr im Monat und sind am aktivsten in der Benutzung der Geräte und Werkzeuge, sowie der Gestaltung des xHains. Im Wiki erfährt ihr <a href="https://wiki.x-hain.de/de/xHain/members">mehr Details über die Mitgliedschaft</a>.
 
 Ihr könnt euch <a href="https://login.x-hain.de/if/flow/xhain-member-enrollment/">hier anmelden</a>, um Member zu werden. Ihr bekommt dann eine Mail mit allen weitern Details.
 
@@ -29,7 +29,7 @@ Für eure Projekte gib es die folgenden Arbeitsbereiche und Ausstattung:
 
 ![](/images/space-map.png)
 
-Die Arbeitsbereiche und deren Werkeuge sind farblich markiert. Manche Geräte erfordern eine Sicherheitseinweisung durch eine authorisierte Person. Im Wiki findet ihr einen genaueren <a href="https://wiki.x-hain.de/de/Rooms_and_Equipment/rooms-and-equipment" target="_blank">Überblick über unsere Arbeitsbereiche und Geräte</a>.
+Die Arbeitsbereiche und deren Werkeuge sind farblich markiert. Manche Geräte erfordern eine Sicherheitseinweisung durch eine authorisierte Person. Im Wiki findet ihr einen genaueren <a href="https://wiki.x-hain.de/de/Rooms_and_Equipment/rooms-and-equipment">Überblick über unsere Arbeitsbereiche und Geräte</a>.
 
 ## Veranstaltungen
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -31,11 +31,11 @@ Whether you're a hacker, maker, or just curious, you're welcome at xHain! It doe
 
 **We want everyone to feel comfortable at xHain!**
 
-<a href="https://wiki.x-hain.de/en/xHain/xRoots" target="_blank"><img alt="xRoots symbol" src="/images/logo/xroots.png" style="float: left; padding: 10px 15px 0 0; width: 85px; height: auto;" /></a>
+<a href="https://wiki.x-hain.de/en/xHain/xRoots"><img alt="xRoots symbol" src="/images/logo/xroots.png" style="float: left; padding: 10px 15px 0 0; width: 85px; height: auto;" /></a>
 
-Our <a href="https://wiki.x-hain.de/en/xHain/xRoots" target="_blank">xRoots mentors</a> are here to help you get started, show you around at xHain, and answer your questions. If you have special needs or concerns, we will take care of them. Just look for people with the xRoots logo/badge on monday nights or talk to us in the <a href="https://chat.x-hain.de" target="_blank">chat</a>.
+Our <a href="https://wiki.x-hain.de/en/xHain/xRoots">xRoots mentors</a> are here to help you get started, show you around at xHain, and answer your questions. If you have special needs or concerns, we will take care of them. Just look for people with the xRoots logo/badge on monday nights or talk to us in the <a href="https://chat.x-hain.de">chat</a>.
 
-xHain is a smoke-free place. If you want to smoke, you can do so outside. If you are an asshole, e.g. sexist, racist, or homophobic, don't bother coming. Please read and follow our <a href="https://wiki.x-hain.de/en/xHain/spacerules" target="_blank">space rules</a>. 
+xHain is a smoke-free place. If you want to smoke, you can do so outside. If you are an asshole, e.g. sexist, racist, or homophobic, don't bother coming. Please read and follow our <a href="https://wiki.x-hain.de/en/xHain/spacerules">space rules</a>. 
 
 ## The space
 

--- a/content/en/participate.md
+++ b/content/en/participate.md
@@ -4,12 +4,12 @@ date: 2021-06-15
 draft: false
 ---
 
-You are always welcome to drop by, but we don't have regular opening hours except for Monday evening. Many active members have a key themselves. If the space is just open or events are announced, every person is always welcome. Feel free to ask in the <a href="https://chat.x-hain.de" target="_blank">chat</a>, when someone is at xHain.
+You are always welcome to drop by, but we don't have regular opening hours except for Monday evening. Many active members have a key themselves. If the space is just open or events are announced, every person is always welcome. Feel free to ask in the <a href="https://chat.x-hain.de">chat</a>, when someone is at xHain.
 xHain sees itself as a do-ocracy and thrives from the commitment and ideas of the members. This means that members independently select and execute their projects.
 
 ## Become a member
 
-Members are the heart of our space. Typically, members donate €13.37 or more per month and are most active in the use of equipment and tools, as well as the design of xHain. See our wiki for <a href="https://wiki.x-hain.de/en/xHain/members" target="_blank">more details about membership</a>.
+Members are the heart of our space. Typically, members donate €13.37 or more per month and are most active in the use of equipment and tools, as well as the design of xHain. See our wiki for <a href="https://wiki.x-hain.de/en/xHain/members">more details about membership</a>.
 
 You can <a href="https://login.x-hain.de/if/flow/xhain-member-enrollment/">register here</a> to become a member. You will receive a mail with all further details.
 
@@ -29,7 +29,7 @@ For your projects there are the following work areas and equipment:
 
 ![](/images/space-map.png)
 
-The work areas and their tools are marked in color. Some devices require a safety briefing by an authorized person. In our wiki you will find a more <a href="https://wiki.x-hain.de/en/Rooms_and_Equipment/rooms-and-equipment" target="_blank">detailed overview of our work areas and devices</a>.
+The work areas and their tools are marked in color. Some devices require a safety briefing by an authorized person. In our wiki you will find a more <a href="https://wiki.x-hain.de/en/Rooms_and_Equipment/rooms-and-equipment">detailed overview of our work areas and devices</a>.
 
 ## Events
 

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -2,7 +2,7 @@
 <div id="frontpage-hero">
   <div class="image-attribution">
     <button class="image-attribution-button" title="Toggle attribution" aria-label="Toggle attribution" aria-pressed="false"></button>
-    <div class="image-attribution-inner" role="list">Photo by <a href="https://nezoomie.pictures" target="_blank">NeZoomie Pictures</a></div>
+    <div class="image-attribution-inner" role="list">Photo by <a href="https://nezoomie.pictures">NeZoomie Pictures</a></div>
   </div>
 </div>
 <div id="content">

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -9,7 +9,7 @@
         <button class="image-attribution-button" title="Toggle attribution" aria-label="Toggle attribution" aria-pressed="false"></button>
         <div class="image-attribution-inner" role="list">
           {{ if .Params.image_url }}
-          <a href="{{ .Params.image_url }}" target="_blank">
+          <a href="{{ .Params.image_url }}">
           {{ end }}
             {{ .Params.image_reference }}
           {{ if .Params.image_url }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -13,7 +13,7 @@
           <button class="image-attribution-button" title="Toggle attribution" aria-label="Toggle attribution" aria-pressed="false"></button>
           <div class="image-attribution-inner" role="list">
             {{ if .Params.image_url }}
-            <a href="{{ .Params.image_url }}" target="_blank">
+            <a href="{{ .Params.image_url }}">
             {{ end }}
               {{ .Params.image_reference }}
             {{ if .Params.image_url }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
         <ul>
           {{- $currentPage := . -}} {{ range .Site.Menus.tools -}}
           <li class="">
-            <a href="{{ .URL | absLangURL }}" target="blank" class="">
+            <a href="{{ .URL | absLangURL }}" class="">
               {{ .Name }}
             </a>
           </li>
@@ -30,7 +30,7 @@
         <ul>
           {{- $currentPage := . -}} {{ range .Site.Menus.social -}}
           <li class="">
-            <a href="{{ .URL | absLangURL }}" target="blank" rel="me" class="">
+            <a href="{{ .URL | absLangURL }}" rel="me" class="">
               {{ .Name }}
             </a>
           </li>


### PR DESCRIPTION
For people a link that opens in a new window window any indication is often a surprise (annoying one). Thanks to Richard for finding this!

For accessibility, see 
https://www.w3.org/TR/WCAG20-TECHS/H83.html
>... confusion that may be caused by the appearance of new windows that were not requested by the user. Suddenly opening new windows can disorient users or be missed completely by some.

It's recommended to have an indication that the links would open in a new window.

I suggest we actually remove the `target="blank"` behavior everywhere for simplicity.

