### PR TITLE
fix: add missing slash to broken links

### DIFF
--- a/assets/css/_button.scss
+++ b/assets/css/_button.scss
@@ -1,8 +1,8 @@
 .button {
-  background-color: #aed919;
+  background-color: $link-color;
   cursor: pointer;
   border: none;
-  color: #002225;
+  color: $base-color;
   padding: 5px;
   text-align: center;
   text-decoration: none;
@@ -11,6 +11,11 @@
   margin: 4px 2px;
   border-radius: 4px;
   font-family: $font-family-brand;
+}
+
+.button:hover {
+  color: $font-color;
+  background-color: $tertiary-color;
 }
 
 .button-nav {

--- a/layouts/partials/memberbutton.html
+++ b/layouts/partials/memberbutton.html
@@ -1,7 +1,7 @@
-<button class="button-nav" onclick="window.location.href='https://login.x-hain.de/if/flow/xhain-member-enrollment'">
-  {{ if strings.Contains .Site.Language.Lang "en" }}
-  become a member
-  {{ else }}
-  member werden
-  {{ end }}
-</button>
+<a
+  class="button-nav"
+  href="https://login.x-hain.de/if/flow/xhain-member-enrollment/"
+>
+  {{ if strings.Contains .Site.Language.Lang "en" }} become a member {{ else }}
+  member werden {{ end }}
+</a>

--- a/layouts/shortcodes/memberbutton.html
+++ b/layouts/shortcodes/memberbutton.html
@@ -1,10 +1,9 @@
-<div style="padding: 20px; text-align: center;">
-  <button class="button-inline"
-    onclick="window.location.href='https://login.x-hain.de/if/flow/xhain-member-enrollment'">
-    {{ if strings.Contains (.Get 0) "en" }}
-    become a member
-    {{ else }}
-    member werden
-    {{ end }}
-  </button>
+<div style="padding: 20px; text-align: center">
+  <a
+    class="button-inline"
+    href="https://login.x-hain.de/if/flow/xhain-member-enrollment/"
+  >
+    {{ if strings.Contains (.Get 0) "en" }} become a member {{ else }} member
+    werden {{ end }}
+  </a>
 </div>


### PR DESCRIPTION
The "become a member" link is broken on the _participate_ pages. This is due to the link missing a trailing slash. It is not good that the routing is this sensitive but I do not know where this controlled so in the PR I'm just adding the slash.

I have converted the button tag to a link tag as this is a link not a button. If a user has JS disable this button wont work but as a link it still will.

I also gave the button a hover style in accordance with a11y guidelines 