### PR TITLE
fix: correctly align days in calendar

### DIFF
--- a/assets/css/_calendar.scss
+++ b/assets/css/_calendar.scss
@@ -12,15 +12,17 @@
         z-index: -2;
         width: 100%;
         height: 100%;
-        background: linear-gradient(60deg,
-                hsl(224, 85%, 66%),
-                hsl(269, 85%, 66%),
-                hsl(314, 85%, 66%),
-                hsl(359, 85%, 66%),
-                hsl(44, 85%, 66%),
-                hsl(89, 85%, 66%),
-                hsl(134, 85%, 66%),
-                hsl(179, 85%, 66%));
+        background: linear-gradient(
+            60deg,
+            hsl(224, 85%, 66%),
+            hsl(269, 85%, 66%),
+            hsl(314, 85%, 66%),
+            hsl(359, 85%, 66%),
+            hsl(44, 85%, 66%),
+            hsl(89, 85%, 66%),
+            hsl(134, 85%, 66%),
+            hsl(179, 85%, 66%)
+        );
         background-size: 300% 300%;
         background-position: 0 50%;
         border-radius: calc(2 * var(--border-width));
@@ -100,8 +102,6 @@
                 background-color: $link-color;
             }
         }
-
-
     }
 
     .day {
@@ -228,11 +228,10 @@
         grid-column: 6;
     }
 
-    .day-6:first-child {
+    .day-7:first-child {
         grid-column: 7;
     }
 }
-
 
 .overlay {
     position: fixed;


### PR DESCRIPTION
From Matrix:

> niklas
> 01:21 AM
> 
> small Bug-Report regarding the Calendar on the website:
> for the month of june the formatting is off by one day, june starts on saturday but the first of june is displayed in the sunday colum, this problem persits for the full month of june (e.g. sundays in the monday colum, ...)


It seems like there was a copy-paste error in the CSS classnames. I fixed this.