### PR TITLE
Fix calendar subscription url

### DIFF
--- a/content/de/calendar/subscribe.md
+++ b/content/de/calendar/subscribe.md
@@ -6,4 +6,4 @@ draft: false
 
 Integriere den xHain-Veranstaltungskalender in deine bevorzugte Kalender-App oder -Programm mittels CalDAV. Füge dafür einfach einen neuen Kalender in deiner Anwendung hinzu und kopiere die folgenden URL dort hinein:
 
-`https://files.x-hain.de/apps/calendar/p/Yi63cicwgDnjaBHR`
+`https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export`

--- a/content/en/calendar/subscribe.md
+++ b/content/en/calendar/subscribe.md
@@ -6,5 +6,5 @@ draft: false
 
 Easily add the xHain event calendar to your preferred calendar app or programm on any device. Simply use CalDAV to integrate our events. To do so, add a new calendar in your application and copy and input this url:
 
-`https://files.x-hain.de/apps/calendar/p/Yi63cicwgDnjaBHR`
+`https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export`
 


### PR DESCRIPTION
I had issues trying to subscribe to the given URL in Gnome Calendar, it kept on asking for credentials. I replaced it with the URL that"s shown in Nextcloud's user interface (which loads when opening the original link in a browser).