### PR TITLE
chore: de-duplicate docker image reference

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,7 +2,7 @@ when:
   branch: [main, staging]
 steps:
   build:
-    image: eclipsefdn/hugo-node:h0.120.4-n18.18.2
+    image: &hugo eclipsefdn/hugo-node:h0.120.4-n18.18.2
     commands:
       - ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
       - hugo version
@@ -12,7 +12,7 @@ steps:
       branch: [main]
 
   build-staging:
-    image: eclipsefdn/hugo-node:h0.120.4-n18.18.2
+    image: *hugo
     commands:
       - ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
       - hugo version
@@ -56,7 +56,7 @@ steps:
       branch: [staging]
 
   build-preview:
-    image: eclipsefdn/hugo-node:h0.120.4-n18.18.2
+    image: *hugo
     commands:
       - ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
       - hugo version


### PR DESCRIPTION
This should make it easier to update the Hugo version (which is now v0.147 😱)