### PR TITLE
Adds healthcheck to monitor cron based CI runs

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -46,7 +46,8 @@ steps:
       HEALTHCHECK_URL:
         from_secret: healthcheck_url
     when:
-      event: [cron, pull_request]
+      event: [cron]
+      branch: [main]
 
   deploy_staging:
     image: drillster/drone-rsync

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -38,6 +38,16 @@ steps:
       event: [push, tag, deployment, cron, manual]
       branch: [main]
 
+  cron_healthcheck:
+    image: alpine/curl
+    commands:
+      - "curl -X GET $${HEALTHCHECK_URL}"
+    environment:
+      HEALTHCHECK_URL:
+        from_secret: healthcheck_url
+    when:
+      event: [cron, pull_request]
+
   deploy_staging:
     image: drillster/drone-rsync
     settings:


### PR DESCRIPTION
The CI seems to stall from time to time. A simple restart helps with it, but I'd like to be informed if this happens. I'm using healthchecks.io for monitoring cron jobs.

This PR adds an additional step to the pipeline of the hourly cron job on main which calls my healthchecks.io monitoring.