### PR TITLE
Implement dynamic rendering of calendar with golang backend

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ resources/
 .hugo_build.lock
 content/de/calendar.md
 content/en/calendar.md
+
+.direnv/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.23.4-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+
+RUN go build -o xhain-calendar-backend cmd/backend/main.go
+
+FROM alpine:3.21.0
+
+COPY --from=builder /app/xhain-calendar-backend /app/xhain-calendar-backend
+
+EXPOSE 8080
+
+CMD ["/app/xhain-calendar-backend"]

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/xHain-hackspace/xhain-website/backend/internal/calendar"
+	"github.com/xHain-hackspace/xhain-website/backend/internal/config"
+	"github.com/xHain-hackspace/xhain-website/backend/internal/i18n"
+)
+
+type TemplateData struct {
+	Months []MonthData
+}
+
+type MonthData struct {
+	Year      int
+	Month     string
+	MonthName string
+	Days      []DayData
+}
+
+type DayData struct {
+	Date          time.Time
+	Day           int
+	WeekdayNumber int
+	WeekdayName   string
+	Events        []calendar.CalendarEvent
+	IsEmpty       bool
+}
+
+func getDateRange() (time.Time, time.Time) {
+	now := time.Now()
+	// The first of the month has to be a 00:00:00 hours otherwise the math goes wonky
+	startDate := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	endDate := startDate.AddDate(0, cfg.Calendar.MonthsToShow, 0)
+	return startDate, endDate
+}
+
+func getDayData(day time.Time, events []calendar.CalendarEvent, language string) DayData {
+	eventsOnDay := calendar.FilterEventsByDay(events, day)
+	weekdayNames := i18n.GetWeekdayNames(language)
+	return DayData{
+		Date:          day,
+		Day:           day.Day(),
+		WeekdayNumber: int(day.Weekday()),
+		WeekdayName:   weekdayNames[day.Weekday()],
+		Events:        eventsOnDay,
+		IsEmpty:       len(eventsOnDay) == 0,
+	}
+}
+
+func getMonthData(month time.Time, events []calendar.CalendarEvent, language string) MonthData {
+	days := []DayData{}
+
+	monthNames := i18n.GetMonthNames(language)
+
+	// Get all days in the month
+	startOfMonth, endOfMonth := getDateRange()
+	for d := startOfMonth; d.Before(endOfMonth); d = d.AddDate(0, 0, 1) {
+		days = append(days, getDayData(d, events, language))
+	}
+
+	return MonthData{
+		Year:      month.Year(),
+		Month:     month.Month().String(),
+		MonthName: monthNames[month.Month()],
+		Days:      days,
+	}
+}
+
+func transformCalendarEvents(events []calendar.CalendarEvent, language string) *TemplateData {
+	months := []MonthData{}
+	startDate, endDate := getDateRange()
+
+	for startDate.Before(endDate) {
+		months = append(months, getMonthData(startDate, events, language))
+		startDate = startDate.AddDate(0, 1, 0)
+	}
+	return &TemplateData{
+		Months: months,
+	}
+}
+
+func calendarHandler(w http.ResponseWriter, r *http.Request) {
+	// Calculate date range using configured months
+	startDate, endDate := getDateRange()
+
+	// get language from url from the first part of the path
+	language := r.PathValue("language")
+	if language != "de" && language != "en" {
+		language = "en"
+	}
+
+	// get template
+	tmpl, err := template.ParseFiles(filepath.Join(cfg.Server.StaticContent, language, "calendar", "index.html"))
+	if err != nil {
+		log.Printf("Error parsing template: %v", err)
+		http.Error(w, "Failed to load template", http.StatusInternalServerError)
+		return
+	}
+
+	// Get calendar data
+	calendarEvents, err := cal.GetEvents(startDate, endDate)
+	if err != nil {
+		log.Printf("Error fetching calendar data: %v", err)
+		http.Error(w, "Failed to load calendar data", http.StatusInternalServerError)
+		return
+	}
+	transformedData := transformCalendarEvents(calendarEvents, language)
+
+	// Create template data with calendar content
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	err = tmpl.Execute(w, transformedData)
+	if err != nil {
+		log.Printf("Error executing template: %v", err)
+		http.Error(w, "Template execution error", http.StatusInternalServerError)
+		return
+	}
+}
+
+var (
+	configFile string
+	cfg        *config.Config
+	cal        *calendar.Calendar
+)
+
+func init() {
+	flag.StringVar(&configFile, "config", "config.yaml", "Path to the configuration file")
+	flag.Parse()
+}
+
+func main() {
+
+	// Load configuration
+	var err error
+	cfg, err = config.LoadConfig(configFile)
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// Set up logging based on config
+	log.Printf("Starting xHain Calendar Backend with configuration:")
+	log.Printf("  Server: %s:%d", cfg.Server.Host, cfg.Server.Port)
+	log.Printf("  Static content: %s", cfg.Server.StaticContent)
+	log.Printf("  Calendar URL: %s", cfg.Calendar.URL)
+	log.Printf("  Cache TTL: %d minutes", cfg.Calendar.CacheTTLMinutes)
+	log.Printf("  Months to show: %d", cfg.Calendar.MonthsToShow)
+
+	// Set up calendar cache with configured TTL
+	cal = calendar.NewCalendar(time.Duration(cfg.Calendar.CacheTTLMinutes)*time.Minute, cfg.Calendar.URL)
+
+	mux := http.NewServeMux()
+
+	// Validate static content directory
+	if _, err := os.Stat(cfg.Server.StaticContent); os.IsNotExist(err) {
+		log.Fatalf("Static content directory does not exist: %s", cfg.Server.StaticContent)
+	}
+
+	mux.Handle("/", http.FileServer(http.Dir(cfg.Server.StaticContent)))
+
+	// Serve calendar pages
+	mux.HandleFunc("/{language}/calendar/{$}", calendarHandler)
+	mux.HandleFunc("/calendar/{$}", calendarHandler)
+
+	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
+	log.Printf("Starting server on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,0 +1,18 @@
+# xHain Calendar Backend Configuration
+
+# Server settings
+server:
+  port: 8080
+  host: "0.0.0.0"
+  static_content: "../public_html"
+
+# Calendar settings
+calendar:
+  url: "https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR"
+  cache_ttl_minutes: 5
+  months_to_show: 3
+
+# Logging
+logging:
+  level: "info"
+  format: "text" 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,10 @@
+module github.com/xHain-hackspace/xhain-website/backend
+
+go 1.22.0
+
+toolchain go1.24.5
+
+require (
+	github.com/xHain-hackspace/go-jcal v0.0.5
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,6 @@
+github.com/xHain-hackspace/go-jcal v0.0.5 h1:fvAgMaSMuVbYtWdqOG18OpG8XShgOEhq5PKINbT+ToU=
+github.com/xHain-hackspace/go-jcal v0.0.5/go.mod h1:TtrDntq5LuHqIYYnPTBmM5fAD0EMWRf+ZS7H+3XpwHM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/internal/calendar/cache.go
+++ b/backend/internal/calendar/cache.go
@@ -1,0 +1,36 @@
+package calendar
+
+import (
+	"sync"
+	"time"
+)
+
+type CalendarCache struct {
+	data      []CalendarEvent
+	lastFetch time.Time
+	ttl       time.Duration
+	mu        sync.RWMutex
+}
+
+func (cc *CalendarCache) getCachedEvents() ([]CalendarEvent, bool) {
+	cc.mu.RLock()
+	defer cc.mu.RUnlock()
+
+	if cc.data == nil {
+		return nil, false
+	}
+
+	if time.Since(cc.lastFetch) > cc.ttl {
+		return nil, false
+	}
+
+	return cc.data, true
+}
+
+func (cc *CalendarCache) setCachedEvents(data []CalendarEvent) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	cc.data = data
+	cc.lastFetch = time.Now()
+}

--- a/backend/internal/calendar/calendar.go
+++ b/backend/internal/calendar/calendar.go
@@ -1,0 +1,70 @@
+package calendar
+
+import (
+	"log"
+	"time"
+)
+
+type Calendar struct {
+	*CalendarCache
+	baseURL string
+}
+
+func NewCalendar(ttl time.Duration, baseURL string) *Calendar {
+	return &Calendar{
+		CalendarCache: &CalendarCache{
+			ttl: ttl,
+		},
+		baseURL: baseURL,
+	}
+}
+
+type CalendarEvent struct {
+	Summary       string    `json:"summary"`
+	Description   string    `json:"description"`
+	Location      string    `json:"location"`
+	StartTime     time.Time `json:"start_time"`
+	EndTime       time.Time `json:"end_time"`
+	HTMLStartTime string    `json:"html_start_time"`
+	HTMLEndTime   string    `json:"html_end_time"`
+}
+
+func FilterEventsByDay(events []CalendarEvent, day time.Time) []CalendarEvent {
+	eventsOnDay := []CalendarEvent{}
+	for _, event := range events {
+		if event.StartTime.Day() == day.Day() && event.StartTime.Month() == day.Month() && event.StartTime.Year() == day.Year() {
+			eventsOnDay = append(eventsOnDay, event)
+		}
+	}
+	return eventsOnDay
+}
+
+func (c *Calendar) fetchEvents(startDate, endDate time.Time) ([]CalendarEvent, error) {
+	return fetchEvents(c.baseURL, startDate, endDate)
+}
+
+func (c *Calendar) GetEvents(startDate, endDate time.Time) ([]CalendarEvent, error) {
+	// Check cache first
+	if cached, ok := c.getCachedEvents(); ok {
+		log.Printf("Using cached data")
+		return cached, nil
+	}
+	log.Printf("No cached data found, fetching fresh data")
+
+	// measure time taken to fetch events
+	now := time.Now()
+
+	// Fetch fresh data
+	data, err := c.fetchEvents(startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the data
+	c.setCachedEvents(data)
+
+	delta := time.Since(now)
+	log.Printf("Fetch took %s", delta)
+
+	return data, nil
+}

--- a/backend/internal/calendar/remote.go
+++ b/backend/internal/calendar/remote.go
@@ -1,0 +1,75 @@
+package calendar
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/xHain-hackspace/go-jcal"
+)
+
+func fetchEvents(baseURL string, startDate, endDate time.Time) ([]CalendarEvent, error) {
+
+	startUnix := startDate.Unix()
+	endUnix := endDate.Unix()
+
+	// build url using url.Values
+	urlValues := url.Values{}
+	urlValues.Add("export", "1")
+	urlValues.Add("accept", "jcal")
+	urlValues.Add("start", fmt.Sprintf("%d", startUnix))
+	urlValues.Add("end", fmt.Sprintf("%d", endUnix))
+	urlValues.Add("expand", "1")
+
+	calendarURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base URL: %w", err)
+	}
+
+	calendarURL.RawQuery = urlValues.Encode()
+
+	fmt.Println(calendarURL.String())
+
+	resp, err := http.Get(calendarURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch calendar data: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("calendar API returned status %d", resp.StatusCode)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Parse jcal data using JSON unmarshaling
+	var jcalObject jcal.JCalObject
+	if err := json.Unmarshal(body, &jcalObject); err != nil {
+		return nil, fmt.Errorf("failed to parse jcal data: %w", err)
+	}
+
+	events := []CalendarEvent{}
+
+	// Extract events from jcal data
+	for _, event := range jcalObject.Events {
+		calendarEvent := CalendarEvent{
+			Summary:       event.Summary,
+			Description:   event.Description,
+			Location:      event.Location,
+			StartTime:     event.DtStart,
+			EndTime:       event.DtEnd,
+			HTMLStartTime: event.DtStart.Format("2006-01-02T15:04:05-0700"),
+			HTMLEndTime:   event.DtEnd.Format("2006-01-02T15:04:05-0700"),
+		}
+		events = append(events, calendarEvent)
+	}
+
+	return events, nil
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Server struct {
+		Port          int    `yaml:"port"`
+		Host          string `yaml:"host"`
+		StaticContent string `yaml:"static_content"`
+	} `yaml:"server"`
+	Calendar struct {
+		URL             string `yaml:"url"`
+		CacheTTLMinutes int    `yaml:"cache_ttl_minutes"`
+		MonthsToShow    int    `yaml:"months_to_show"`
+	} `yaml:"calendar"`
+	Logging struct {
+		Level  string `yaml:"level"`
+		Format string `yaml:"format"`
+	} `yaml:"logging"`
+}
+
+func LoadConfig(configPath string) (*Config, error) {
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	config := &Config{}
+	if err := yaml.Unmarshal(configData, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return config, nil
+}

--- a/backend/internal/i18n/i18n.go
+++ b/backend/internal/i18n/i18n.go
@@ -1,0 +1,61 @@
+package i18n
+
+import "time"
+
+func GetMonthNames(language string) map[time.Month]string {
+	if language == "de" {
+		return map[time.Month]string{
+			time.January:   "Januar",
+			time.February:  "Februar",
+			time.March:     "März",
+			time.April:     "April",
+			time.May:       "Mai",
+			time.June:      "Juni",
+			time.July:      "Juli",
+			time.August:    "August",
+			time.September: "September",
+			time.October:   "Oktober",
+			time.November:  "November",
+			time.December:  "Dezember",
+		}
+	} else {
+		return map[time.Month]string{
+			time.January:   "January",
+			time.February:  "February",
+			time.March:     "March",
+			time.April:     "April",
+			time.May:       "May",
+			time.June:      "June",
+			time.July:      "July",
+			time.August:    "August",
+			time.September: "September",
+			time.October:   "October",
+			time.November:  "November",
+			time.December:  "December",
+		}
+	}
+}
+
+func GetWeekdayNames(language string) map[time.Weekday]string {
+	if language == "de" {
+		return map[time.Weekday]string{
+			time.Monday:    "Mon",
+			time.Tuesday:   "Tue",
+			time.Wednesday: "Wed",
+			time.Thursday:  "Thu",
+			time.Friday:    "Fri",
+			time.Saturday:  "Sat",
+			time.Sunday:    "Sun",
+		}
+	} else {
+		return map[time.Weekday]string{
+			time.Monday:    "Mon",
+			time.Tuesday:   "Tue",
+			time.Wednesday: "Wed",
+			time.Thursday:  "Thu",
+			time.Friday:    "Fri",
+			time.Saturday:  "Sat",
+			time.Sunday:    "Sun",
+		}
+	}
+}

--- a/config.toml
+++ b/config.toml
@@ -5,36 +5,36 @@ languageCode = "en-us"
 defaultContentLanguage = "de"
 DefaultContentLanguageInSubdir = true
 MetaDataFormat = "yaml"
-timeZone="Europe/Berlin"
+timeZone = "Europe/Berlin"
 
 [pagination]
 # Define the number of posts per page
 pagerSize = 6
 
 [permalinks]
-  post = "/:year/:month/:slug/"
+post = "/:year/:month/:slug/"
 
 [params]
-  author = "xHain hack+makespace"
-  defaultKeywords = ["hackspace", "makerspace", "xhain"]
-  email = "info@x-hain.de"
-  calendar = "https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export&accept=jcal&start=%d&end=%d&expand=1"
-  latitude = "52.512815"
-  longitude = "13.4493919"
-  og_image = "/images/hero.jpg"
+author = "xHain hack+makespace"
+defaultKeywords = ["hackspace", "makerspace", "xhain"]
+email = "info@x-hain.de"
+calendar = "https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export&accept=jcal&start=%d&end=%d&expand=1"
+latitude = "52.512815"
+longitude = "13.4493919"
+og_image = "/images/hero.jpg"
 
 [Permalinks]
-    articles = "/blog/:year/:month/:day/:title/"
+articles = "/blog/:year/:month/:day/:title/"
 
 [outputs]
-  home = ["HTML", "RSS"]
-  page = ["HTML"]
-  section = ["HTML"]
-  taxonomy = ["HTML"]
-  term = ["HTML"]
+home = ["HTML", "RSS"]
+page = ["HTML"]
+section = ["HTML"]
+taxonomy = ["HTML"]
+term = ["HTML"]
 
 [markup.goldmark.renderer]
-  unsafe= true
+unsafe = true
 
 
 ###### TRANSLATIONS ######
@@ -83,129 +83,129 @@ title = "Find us elsewhere"
 ###### MAIN MENU ######
 
 [[languages.de.menu.main]]
-  weight = 1
-  identifier = "about"
-  name = "Vorbeikommen"
-  url = ""
+weight = 1
+identifier = "about"
+name = "Vorbeikommen"
+url = ""
 
 [[languages.de.menu.main]]
-  weight = 2
-  identifier = "participate"
-  name = "Mitmachen"
-  url = "participate"
+weight = 2
+identifier = "participate"
+name = "Mitmachen"
+url = "participate"
 
 [[languages.de.menu.main]]
-  weight = 3
-  identifier = "support"
-  name = "Unterstützen"
-  url = "support"
+weight = 3
+identifier = "support"
+name = "Unterstützen"
+url = "support"
 
 
 [[languages.en.menu.main]]
-  weight = 1
-  identifier = "about"
-  name = "Drop by"
-  url = ""
+weight = 1
+identifier = "about"
+name = "Drop by"
+url = ""
 
 [[languages.en.menu.main]]
-  weight = 2
-  identifier = "participate"
-  name = "Participate"
-  url = "participate"
+weight = 2
+identifier = "participate"
+name = "Participate"
+url = "participate"
 
 [[languages.en.menu.main]]
-  weight = 3
-  identifier = "support"
-  name = "Support"
-  url = "support"
+weight = 3
+identifier = "support"
+name = "Support"
+url = "support"
 
 ###### TOOLS MENU ######
 
 [[languages.de.menu.tools]]
-  weight = 1
-  identifier = "blog"
-  name = "Blog"
-  url = "blog"
+weight = 1
+identifier = "blog"
+name = "Blog"
+url = "blog"
 
 [[languages.de.menu.tools]]
-  weight = 2
-  identifier = "matrix"
-  name = "Chat"
-  url = "https://matrix.to/#/#xhain:x-hain.de"
+weight = 2
+identifier = "matrix"
+name = "Chat"
+url = "https://matrix.to/#/#xhain:x-hain.de"
 
 [[languages.de.menu.tools]]
-  weight = 3
-  identifier = "wiki"
-  name = "Wiki"
-  url = "https://wiki.x-hain.de/"
+weight = 3
+identifier = "wiki"
+name = "Wiki"
+url = "https://wiki.x-hain.de/"
 
 [[languages.en.menu.tools]]
-  weight = 1
-  identifier = "blog"
-  name = "Blog"
-  url = "blog"
+weight = 1
+identifier = "blog"
+name = "Blog"
+url = "blog"
 
 [[languages.en.menu.tools]]
-  weight = 2
-  identifier = "matrix"
-  name = "Chat"
-  url = "https://matrix.to/#/#xhain:x-hain.de"
+weight = 2
+identifier = "matrix"
+name = "Chat"
+url = "https://matrix.to/#/#xhain:x-hain.de"
 
 [[languages.en.menu.tools]]
-  weight = 3
-  identifier = "wiki"
-  name = "Wiki"
-  url = "https://wiki.x-hain.de/"
+weight = 3
+identifier = "wiki"
+name = "Wiki"
+url = "https://wiki.x-hain.de/"
 
 ###### SOCIAL MENU ######
 
 [[languages.de.menu.social]]
-  weight = 1
-  identifier = "fediverse"
-  name = "Fediverse"
-  url = "https://chaos.social/@xHain_hackspace"
+weight = 1
+identifier = "fediverse"
+name = "Fediverse"
+url = "https://chaos.social/@xHain_hackspace"
 
 [[languages.de.menu.social]]
-  weight = 2
-  identifier = "github"
-  name = "Github"
-  url = "https://github.com/xHain-hackspace/"
+weight = 2
+identifier = "github"
+name = "Github"
+url = "https://github.com/xHain-hackspace/"
 
 [[languages.en.menu.social]]
-  weight = 1
-  identifier = "fediverse"
-  name = "Fediverse"
-  url = "https://chaos.social/@xHain_hackspace"
+weight = 1
+identifier = "fediverse"
+name = "Fediverse"
+url = "https://chaos.social/@xHain_hackspace"
 
 [[languages.en.menu.social]]
-  weight = 2
-  identifier = "github"
-  name = "Github"
-  url = "https://github.com/xHain-hackspace/"
+weight = 2
+identifier = "github"
+name = "Github"
+url = "https://github.com/xHain-hackspace/"
 
 
 ###### FOOTER MENU ######
 
 [[languages.de.menu.footer]]
-  weight = 1
-  identifier = "contact"
-  name = "Kontakt"
-  url = "contact"
+weight = 1
+identifier = "contact"
+name = "Kontakt"
+url = "contact"
 
 [[languages.de.menu.footer]]
-  weight = 2
-  identifier = "privacy"
-  name = "Datenschutz"
-  url = "privacy"
+weight = 2
+identifier = "privacy"
+name = "Datenschutz"
+url = "privacy"
 
 [[languages.en.menu.footer]]
-  weight = 1
-  identifier = "contact"
-  name = "Contact"
-  url = "contact"
+weight = 1
+identifier = "contact"
+name = "Contact"
+url = "contact"
 
 [[languages.en.menu.footer]]
-  weight = 2
-  identifier = "privacy"
-  name = "Privacy"
-  url = "privacy"
+weight = 2
+identifier = "privacy"
+name = "Privacy"
+url = "privacy"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753939845,
+        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "xHain website development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            hugo
+            nodejs # For any potential Node.js dependencies
+            go
+          ];
+
+          shellHook = ''
+            echo "xHain website development environment"
+            echo "Hugo version: $(hugo version)"
+          '';
+        };
+      }
+    );
+}

--- a/layouts/calendar/list.html
+++ b/layouts/calendar/list.html
@@ -1,60 +1,22 @@
 {{ define "main" }}
-{{ $monthCount := 3 }}
-{{ $now:= time.Now }}
-{{/* The first of the month has to be a 00:00:00 hours otherwise the math goes wonky */}}
-{{ $start := print ($now.Format "2006-01") "-01" }}
-{{ $startDate := time.AsTime $start "CET" }}
-{{ $endDate := $startDate.AddDate 0 $monthCount 0 }}
-{{ $url := printf .Site.Params.calendar $startDate.Unix $endDate.Unix }}
-{{ $data := (resources.GetRemote $url) | transform.Unmarshal }}
-{{ $datetypes := slice "date-time" "date" }}
-{{ $events := slice }}
-{{/*  parse all the start and end times into local  */}}
-{{ range (index $data 2) }}
-  {{ $oldEvent := . }}
-  {{ $event := dict }}
-  {{ range (index $oldEvent 1 ) }}
-    {{ if (in $datetypes (index . 2 )) }}
-      {{ $event = merge $event (dict (index . 0) (time.AsTime (index . 3)).Local) }}
-    {{ else }}
-      {{ $event = merge $event (dict (index . 0) (index . 3)) }}
-    {{ end }}
-  {{ end }}
-  {{ $events = $events | append $event }}
-{{ end }}
 <main>
     <div id="main-wrapper" class="calendar-wrapper">
         <div id="xhain_calendar" class="calendar">
             <h1 id="article-title">{{ .Title }}</h1>
-            {{ range $i, $month := (seq $monthCount) }}
-                {{ $startOfMonth := $startDate.AddDate 0 $i 0 }}
-                {{ $endOfMonth := $startOfMonth.AddDate 0 1 0 }}
-                {{ $monthLength := $endOfMonth.Sub $startOfMonth}}
-                {{/*  add 1 to account for daylight savings  */}}
-                {{ $hoursInMonth:= add ($monthLength.Hours | int) 1 }}
-                {{ $daysInMonth := math.Round (div $hoursInMonth 24) }}
-                {{/* TODO: make these dates dynamic for this month to two months
-                from now */}} {{/* This filtering reduces the list that later
-                has to be filtered on every day. Not sure if this is really a
-                performance boost (no idea how to measure) */}}
+            {{ printf "{{ range .Months }}" }}
                 <div class="month_wrapper">
                     <div class="month_header">
-                        <div class="year">{{ $startOfMonth.Year }}</div>
+                        <div class="year">{{ printf "{{ .Year }}" }}</div>
                         <a class="subscribe" href="{{ urls.RelLangURL "" }}/calendar/subscribe">{{ i18n "global.subscribe" }}</a>
-                        <div class="month">{{ T $startOfMonth.Month }}</div>
+                        <div class="month">{{ printf "{{ .MonthName }}" }}</div>
                     </div>
                     <div class="days_wrapper">
-                        {{ range $i, $sequence := (seq $daysInMonth) }}
-                            {{ $thisDate := $startOfMonth.AddDate 0 0 ( $i | int) }}
-                            {{ $nextDate := $thisDate.AddDate 0 0 1 }}
-                            {{ $todayEvents := where $events  ".dtstart" "lt" $nextDate }}
-                            {{ $todayEvents := where $todayEvents  ".dtstart" "ge" $thisDate }}
-                            {{ partial "calendar-day.html" (dict "date" $thisDate "events" $todayEvents) }}
-                        {{ end }}
+                        {{ printf "{{ range .Days }}" }}
+                            {{ partial "calendar-day.html" . }}
+                        {{ printf "{{ end }}" | safeHTML }}
                     </div>
                 </div>
-
-            {{ end }}
+            {{ printf "{{ end }}" | safeHTML }}
         </div>
     </div>
 

--- a/layouts/partials/calendar-day.html
+++ b/layouts/partials/calendar-day.html
@@ -1,11 +1,16 @@
-{{ $fullDate := .date.Format "2006-01-02" }}
-{{ $weekday := .date.Format "Mon" }}
-<div class="day day-{{.date.Weekday|int}} {{if not .events}}day-empty{{end}}" id="{{$fullDate}}">
+{{ printf `
+{{ $fullDate := .Date.Format "2006-01-02" }}
+{{ $weekday := .Date.Format "Mon" }}
+<div class="day day-{{ .WeekdayNumber }} {{if not .Events}}day-empty{{end}}" id="{{$fullDate}}">
   <div class="day_title">
-    <time class="monthday" datetime="{{$fullDate}}">{{.date.Day}}</time>
-    <span class="weekday">{{T $weekday}}</span>
+      <time class="monthday" datetime="{{$fullDate}}">{{ .Date.Day }}</time>
+      <span class="weekday">{{ $weekday }}</span>
+  </div>
+
+  {{ range .Events }}
+` | safeHTML }}
+      {{ partial "calendar-event.html" . }}
+{{ printf `
+  {{ end }}
 </div>
-{{range sort .events ".dtstart"}} 
-  {{ partial "calendar-event.html" . }} 
-{{end}}
-</div>
+` | safeHTML }}

--- a/layouts/partials/calendar-event.html
+++ b/layouts/partials/calendar-event.html
@@ -1,25 +1,26 @@
-{{ $formattedStartTime := .dtstart.Format "15:04" }}
-{{ $formattedEndTime := .dtend.Format "15:04" }}
+{{ printf `
+{{ $formattedStartTime := .StartTime.Format "15:04" }}
+{{ $formattedEndTime := .EndTime.Format "15:04" }}
 <div
     class="event"
     z-index="-1"
     role="button"
     aria-haspopup="dialog"
-    data-start-time="{{.dtstart.Format "2006-01-02T15:04:05-0700" }}"
-    data-end-time="{{.dtend.Format "2006-01-02T15:04:05-0700" }}"
-    data-formatted-start-time="{{$formattedStartTime}}"
-    data-formatted-end-time="{{$formattedEndTime}}"
-    data-title="{{.summary}}"
-    data-location="{{.Location}}"
-    data-description="{{.description}}"
+    data-start-time="{{ .HTMLStartTime }}"
+    data-end-time="{{ .HTMLEndTime }}"
+    data-formatted-start-time="{{ $formattedStartTime }}"
+    data-formatted-end-time="{{ $formattedEndTime }}"
+    data-title="{{ .Summary }}"
+    data-location="{{ .Location }}"
+    data-description="{{ .Description }}"
 >
     <div class="time">
-        <time class="start" datetime="{{$formattedStartTime}}" aria-label="start">
-            {{$formattedStartTime}}
+        <time class="start" datetime="{{ $formattedStartTime }}" aria-label="start">
+            {{ $formattedStartTime }}
         </time>
-        <time class="end" datetime="{{$formattedEndTime}}" aria-label="end">
-            {{$formattedEndTime}}
+        <time class="end" datetime="{{ $formattedEndTime }}" aria-label="end">
+            {{ $formattedEndTime }}
         </time>
     </div>
-    <span class="title">{{.summary}}</span>
-</div>
+    <span class="title">{{ .Summary }}</span>
+</div>` | safeHTML }}


### PR DESCRIPTION
This is a kind of hacky way to get the calendar to render dynamically.

It bugs me that we have to run the CI job every hour just to have the calendar up to date.

This implementation uses the output of the hugo build stage to grab the calendar `index.html` as a golang template and render it 


## How to try it out:

Run from repository root:
```sh
hugo -d public_html --config config.toml,home.toml --cleanDestinationDir --baseURL http://localhost:8080
```

Run from ./backend
```sh
go run cmd/backend/main.go
```

Then hit `http://localhost:8080/en/calendar` and you should see the calendar rendered.

This is just a proposal and I'm very open for better ideas. This is the best I could come up with.

## Deployment
I created a Dockerfile for the backend. As we have recently deployed caddy to serve the static site, we could easily implement the logic we use there to distinguish between languages in the backend. That would mean we could replace caddy by the custom golang backend but continue to deploy the hugo site using ssh.