### PR TITLE
fix day alignment of months that start on a Sunday

### DIFF
--- a/assets/css/_calendar.scss
+++ b/assets/css/_calendar.scss
@@ -213,7 +213,7 @@
         grid-column: 6;
     }
 
-    .day-7:first-child {
+    .day-0:first-child {
         grid-column: 7;
     }
 }


### PR DESCRIPTION
Looks like the `{{ .date.Weekday }}` starts on a Sunday because of those silly US Americans, which the calendar CSS grid didn't take into account.

Fixes #102 