### PR TITLE
feat: improve calendar subscribe page and move link to header

### DIFF
--- a/assets/css/_calendar.scss
+++ b/assets/css/_calendar.scss
@@ -79,25 +79,6 @@
             float: right;
             font-size: 2.5rem;
         }
-
-        .subscribe {
-            float: right;
-            margin-top: 0.3rem;
-            margin-right: 0.6rem;
-            padding: 0px 8px;
-            background-color: #000;
-            border-radius: 0.3rem;
-
-            color: grey;
-            font-size: 0.6rem;
-            font-weight: bold;
-            text-decoration: none;
-
-            &:hover {
-                color: #000;
-                background-color: $link-color;
-            }
-        }
     }
 
     .day {
@@ -216,6 +197,12 @@
     .day-0:first-child {
         grid-column: 7;
     }
+}
+
+.calendar_header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
 }
 
 .event_modal {

--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,7 @@ pagerSize = 6
   latitude = "52.512815"
   longitude = "13.4493919"
   og_image = "/images/hero.jpg"
+  matrix = "https://matrix.to/#/#xhain:x-hain.de"
 
 [Permalinks]
     articles = "/blog/:year/:month/:day/:title/"

--- a/content/de/calendar/subscribe.md
+++ b/content/de/calendar/subscribe.md
@@ -4,6 +4,22 @@ date: 2024-03-05
 draft: false
 ---
 
-Integriere den xHain-Veranstaltungskalender in deine bevorzugte Kalender-App oder -Programm mittels CalDAV. Füge dafür einfach einen neuen Kalender in deiner Anwendung hinzu und kopiere die folgenden URL dort hinein:
+So fügst du den xHain-Veranstaltungskalender zu deiner Kalender-App hinzu
 
-`https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export`
+### Mit CalDAV
+
+1. Öffne deine Kalender-App und suche die Option, einen neuen Kalender hinzuzufügen. Diese findest du meist unter "Einstellungen" oder "Konten".
+2. Wähle "CalDAV" als Kontotyp, falls verfügbar.
+3. Kopiere diese URL in das Server-URL-Feld (klicken zum Auswählen):
+
+<input type="text" value="https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export" readonly onclick="this.select()" style="width:100%; padding: 0.5rem; font-family: monospace; background: #ccc;">
+
+4. Speichere den neuen Kalender.
+
+Jetzt siehst du alle xHain-Veranstaltungen direkt in deiner Kalender-App!
+
+So verpasst du keine Workshops, Vorträge, Meetups oder andere Events im xHain.
+
+### Probleme?
+
+Falls du Schwierigkeiten hast, den Kalender hinzuzufügen, schau in die Dokumentation deiner Kalender-App oder melde dich in unserem [Matrix-Chat]({{< param matrix >}}).

--- a/content/en/calendar/subscribe.md
+++ b/content/en/calendar/subscribe.md
@@ -1,10 +1,25 @@
 ---
-title: Subscribe to our calendar
+title: Stay up-to-date with xHain events
 date: 2024-03-05
 draft: false
 ---
 
-Easily add the xHain event calendar to your preferred calendar app or programm on any device. Simply use CalDAV to integrate our events. To do so, add a new calendar in your application and copy and input this url:
+Here's how to add the xHain event calendar to your favorite calendar app
 
-`https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export`
+### Using CalDAV
 
+1. Open your calendar application and look for the option to add a new calendar. This might be under "Settings" or "Accounts."
+2. Choose "CalDAV" as the account type if available.
+3. In the server URL field, copy and paste this link (click to select):
+
+<input type="text" value="https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/?export" readonly onclick="this.select()" style="width:100%; padding: 0.5rem; font-family: monospace; background: #ccc;">
+
+4. Save the new calendar.
+
+Now you'll see all the upcoming xHain events directly in your calendar app!
+
+This way, you won't miss out on workshops, talks, meetups, or any other events happening at xHain.
+
+### Having trouble?
+
+If you encounter any issues adding the calendar, check the documentation for your specific calendar app or reach out on our [Matrix chat]({{< param matrix >}}) for support.

--- a/layouts/calendar/list.html
+++ b/layouts/calendar/list.html
@@ -23,7 +23,10 @@
 <main>
     <div id="main-wrapper" class="calendar-wrapper">
         <div id="xhain_calendar" class="calendar">
-            <h1 id="article-title">{{ .Title }}</h1>
+            <div class="calendar_header">
+                <h1 id="article-title">{{ .Title }}</h1>
+                <a class="subscribe" href="{{ urls.RelLangURL "" }}/calendar/subscribe">{{ i18n "global.subscribe" }}</a>
+            </div>
             {{ range $i, $month := (seq $monthCount) }}
                 {{ $startOfMonth := $startDate.AddDate 0 $i 0 }}
                 {{ $endOfMonth := $startOfMonth.AddDate 0 1 0 }}
@@ -38,7 +41,6 @@
                 <div class="month_wrapper">
                     <div class="month_header">
                         <div class="year">{{ $startOfMonth.Year }}</div>
-                        <a class="subscribe" href="{{ urls.RelLangURL "" }}/calendar/subscribe">{{ i18n "global.subscribe" }}</a>
                         <div class="month">{{ T $startOfMonth.Month }}</div>
                     </div>
                     <div class="days_wrapper">


### PR DESCRIPTION
Replaces https://github.com/xHain-hackspace/xhain-website/pull/75

- Move subscribe link from month headers to main calendar header
- Replace code block URL with clickable input field for easy selection
- Add step-by-step numbered instructions for CalDAV setup
- Add troubleshooting section with Matrix chat link
- Sync German and English versions
- Add .calendar_header flexbox styling