### PR TITLE
feat: only build and deploy when calendar changed

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,54 @@
+# GitHub Actions Scripts
+
+Helper scripts for CI/CD workflows.
+
+## Calendar Change Detection
+
+These scripts detect changes to the xHain calendar by checking the CalDAV CTag (Collection Tag). The CTag changes whenever any event is added, modified, or deleted, allowing efficient change detection without fetching all events.
+
+### fetch-calendar-ctag.sh
+
+Fetches the current CTag from the CalDAV server.
+
+```bash
+# Usage
+.github/scripts/fetch-calendar-ctag.sh [output-file]
+
+# Example
+.github/scripts/fetch-calendar-ctag.sh new.ctag
+# → CTag: http://sabre.io/ns/sync/2530
+```
+
+**Arguments:**
+
+- `output-file` (optional): Where to write the CTag. Defaults to `new.ctag`
+
+**Behavior:**
+
+- Makes a PROPFIND request to the public calendar endpoint
+- Extracts the CTag value from the XML response
+- Falls back to a timestamp-based CTag if the request fails
+
+### compare-ctag.sh
+
+Compares old and new CTag files to determine if a rebuild is needed.
+
+```bash
+# Usage
+.github/scripts/compare-ctag.sh [old-file] [new-file] [force]
+
+# Example
+export GITHUB_OUTPUT=/dev/stdout  # For local testing
+.github/scripts/compare-ctag.sh old.ctag new.ctag false
+# → changed=true or changed=false
+```
+
+**Arguments:**
+
+- `old-file` (optional): Previous CTag file. Defaults to `old.ctag`
+- `new-file` (optional): New CTag file. Defaults to `new.ctag`
+- `force` (optional): Set to `true` to force a rebuild. Defaults to `false`
+
+**Output:**
+
+- Writes `changed=true` or `changed=false` to `$GITHUB_OUTPUT`

--- a/.github/scripts/compare-ctag.sh
+++ b/.github/scripts/compare-ctag.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Compares old and new CTag files to detect calendar changes
+# Usage: compare-ctag.sh <old-ctag-file> <new-ctag-file> [force]
+# Outputs: changed=true or changed=false to $GITHUB_OUTPUT
+
+set -euo pipefail
+
+OLD_CTAG_FILE="${1:-old.ctag}"
+NEW_CTAG_FILE="${2:-new.ctag}"
+FORCE="${3:-false}"
+
+if [ ! -f "$OLD_CTAG_FILE" ]; then
+  echo "No previous CTag found, will trigger build"
+  echo "changed=true" >> "$GITHUB_OUTPUT"
+elif cmp -s "$OLD_CTAG_FILE" "$NEW_CTAG_FILE"; then
+  echo "CTag unchanged, skipping build"
+  echo "changed=false" >> "$GITHUB_OUTPUT"
+else
+  echo "CTag changed!"
+  echo "Old: $(cat "$OLD_CTAG_FILE")"
+  echo "New: $(cat "$NEW_CTAG_FILE")"
+  echo "changed=true" >> "$GITHUB_OUTPUT"
+fi
+
+# Force rebuild if requested
+if [ "$FORCE" == "true" ]; then
+  echo "Force rebuild requested"
+  echo "changed=true" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/fetch-calendar-ctag.sh
+++ b/.github/scripts/fetch-calendar-ctag.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fetches the CTag from a CalDAV calendar to detect changes
+# Usage: fetch-calendar-ctag.sh <output-file>
+#
+# CTag (Collection Tag) is a CalDAV property that changes whenever any
+# event in the calendar is added, modified, or deleted. By comparing
+# the current CTag with the previous one, we can detect calendar changes
+# without fetching and parsing all events.
+
+set -euo pipefail
+
+OUTPUT_FILE="${1:-new.ctag}"
+CALENDAR_URL="https://files.x-hain.de/remote.php/dav/public-calendars/Yi63cicwgDnjaBHR/"
+
+# PROPFIND request to get the CTag (no auth needed for public calendar)
+if ! curl -s --fail --retry 3 --retry-delay 5 --max-time 30 -X PROPFIND \
+  -H "Depth: 0" \
+  -H "Content-Type: application/xml" \
+  "$CALENDAR_URL" \
+  --data '<?xml version="1.0"?>
+  <d:propfind xmlns:d="DAV:" xmlns:cs="http://calendarserver.org/ns/">
+    <d:prop>
+      <cs:getctag/>
+    </d:prop>
+  </d:propfind>' \
+  -o response.xml; then
+  echo "::warning::CalDAV request failed"
+  echo "fallback-$(date +%s)" > "$OUTPUT_FILE"
+  exit 0
+fi
+
+# Extract CTag value using awk (portable)
+CTAG=$(awk -F'[<>]' '/getctag/{for(i=1;i<=NF;i++)if($i~/:getctag$/||$i=="cs:getctag")print $(i+1)}' response.xml)
+
+if [ -z "$CTAG" ]; then
+  echo "::warning::Could not extract CTag from response"
+  cat response.xml
+  CTAG="fallback-$(date +%s)"
+fi
+
+echo "$CTAG" > "$OUTPUT_FILE"
+echo "CTag: $CTAG"
+
+# Cleanup
+rm -f response.xml

--- a/.github/workflows/hourly-update.yml
+++ b/.github/workflows/hourly-update.yml
@@ -1,17 +1,59 @@
-name: Hourly Build and Deploy
+name: Hourly Build and Deploy (if calendar changed)
 
 on:
   schedule:
     - cron: "20 * * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force rebuild even if calendar hasn't changed"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  check-calendar:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.compare.outputs.changed }}
+    steps:
+      - name: Checkout scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Restore cached CTag
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: old.ctag
+          key: calendar-ctag
+
+      - name: Fetch current CTag
+        run: .github/scripts/fetch-calendar-ctag.sh new.ctag
+
+      - name: Compare CTag
+        id: compare
+        run: .github/scripts/compare-ctag.sh old.ctag new.ctag "${{ inputs.force }}"
+
+      - name: Save CTag to cache
+        if: steps.compare.outputs.changed == 'true'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: new.ctag
+          key: calendar-ctag
+
   build:
+    needs: check-calendar
+    if: needs.check-calendar.outputs.changed == 'true'
     uses: ./.github/workflows/build.yml
     with:
       ref: main
+    secrets: inherit
 
   deploy:
-    needs: build
+    needs: [check-calendar, build]
+    if: needs.check-calendar.outputs.changed == 'true'
     uses: ./.github/workflows/deploy.yml
     with:
       artifact-name: ${{ needs.build.outputs.artifact-name }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ resources/
 .hugo_build.lock
 content/de/calendar.md
 content/en/calendar.md
+
+# Local script testing artifacts
+*.ctag
+response.xml


### PR DESCRIPTION
Currently we rebuild and upload a new version of the full website every hour, even when no changes happened.

I discovered that we could use CalDAV CTag to detect calendar changes before triggering builds. This avoids unnecessary rebuilds when the calendar hasn't been modified.

What do you think?

I checked it and this number does go up once in a while, in theory for any change (add/delete/modify) so it's perfect for this use case.

## Local Testing

```bash
# Fetch current CTag and copy it to simulate no change
.github/scripts/fetch-calendar-ctag.sh new.ctag
cp new.ctag old.ctag  # Save as "previous" state

# No change output:
.github/scripts/compare-ctag.sh old.ctag new.ctag
>CTag unchanged, skipping build
>changed=false

# Force change (simulating calendar change)
echo "http://sabre.io/ns/sync/9999" > new.ctag
.github/scripts/compare-ctag.sh old.ctag new.ctag

# Change detected output
>CTag changed!
>Old: http://sabre.io/ns/sync/2530
>New: http://sabre.io/ns/sync/9999
>changed=true
```
