### PR TITLE
chore: remove mention of missing home.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
           hugo env
-          hugo -d public_html --config config.toml,home.toml --cleanDestinationDir
+          hugo -d public_html --config config.toml --cleanDestinationDir
 
       - name: Set artifact name
         id: set-output

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -6,7 +6,7 @@ steps:
     commands:
       - ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
       - hugo version
-      - hugo -d public_html --config config.toml,home.toml --cleanDestinationDir
+      - hugo -d public_html --config config.toml --cleanDestinationDir
     when:
       event: [push, tag, deployment, cron, manual]
       branch: [main]
@@ -16,7 +16,7 @@ steps:
     commands:
       - ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
       - hugo version
-      - hugo -d public_html --config config.toml,home.toml --cleanDestinationDir --baseURL https://staging.x-hain.de
+      - hugo -d public_html --config config.toml --cleanDestinationDir --baseURL https://staging.x-hain.de
     when:
       event: [push, tag, deployment]
       branch: [staging]
@@ -71,7 +71,7 @@ steps:
     commands:
       - ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
       - hugo version
-      - hugo -d public_html --config config.toml,home.toml --cleanDestinationDir --baseURL /
+      - hugo -d public_html --config config.toml --cleanDestinationDir --baseURL /
     when:
       event: pull_request
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ More info? see https://tsalikis.blog/posts/switching_hugo_versions/
 * Run hugo to generate HTML: ``hugo``
 * Run hugo for local development:
 
-   ``hugo server --config config.toml,home.toml``
+   ``hugo server --config config.toml``
 
   or
 
-  ``hugo server --config config.toml,home.toml -w --cleanDestinationDir``
+  ``hugo server --config config.toml -w --cleanDestinationDir``
 
 ## Content Editing
 
@@ -125,7 +125,7 @@ Dead links are automatically checked on pull requests. To run locally:
 
 ```bash
 # Build the site first
-hugo -d public_html --config config.toml,home.toml --cleanDestinationDir
+hugo -d public_html --config config.toml --cleanDestinationDir
 
 # Check for broken links (via Docker)
 docker run --rm -v "$PWD:/src" -w /src ghcr.io/untitaker/hyperlink:0.2.0 \


### PR DESCRIPTION
It existed in the old theme and was deleted in commit https://github.com/xHain-hackspace/xhain-website/commit/ec49d39 on Jun 18, 2021.